### PR TITLE
Update Certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV     TS3_VERSION=3.7.1 \
 
 RUN \
     apk --no-cache add ca-certificates wget; \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub; \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub; \
     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk; \
     apk add glibc-${GLIBC_VERSION}.apk; \
     apk add --update bzip2; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 ### https://github.com/sgerrand/alpine-pkg-glibc
 FROM alpine:latest
 
-ENV     TS3_VERSION=3.5.1 \
-        GLIBC_VERSION='2.27-r0'
+ENV     TS3_VERSION=3.7.1 \
+        GLIBC_VERSION='2.29-r0'
 
 RUN \
     apk --no-cache add ca-certificates wget; \


### PR DESCRIPTION
Because i like to update the apline image to the latest version i got problems with running teamspeak. (ts3server not found).
After more research i found out that glibc is missing.
With a update the location of the cert from the glibc repo has been changed (see github repo of glibc).
i have updated the cert and checked if now everything works.

After this small change everything worked as excepted!