### PR TITLE
Fixes #18: Changes base image to centos7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
 ### Alpine requires glibc to be present in the system below link to fficial repository
 ### https://github.com/sgerrand/alpine-pkg-glibc
-FROM alpine:latest
+FROM centos:7
 
-ENV     TS3_VERSION=3.8.0 \
-        GLIBC_VERSION='2.29-r0'
+ENV     TS3_VERSION=3.8.0
 
 RUN \
-    apk --no-cache add ca-certificates wget; \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub; \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk; \
-    apk add glibc-${GLIBC_VERSION}.apk; \
-    apk add --update bzip2; \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/* /glibc-${GLIBC_VERSION}.apk; \
-    wget http://dl.4players.de/ts/releases/${TS3_VERSION}/teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2 -O /tmp/teamspeak.tar.bz2
+    yum install -y wget bzip2 glibc && \
+    wget http://dl.4players.de/ts/releases/${TS3_VERSION}/teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2 -O /tmp/teamspeak.tar.bz2 && \
+    mkdir -p /opt/teamspeak && \
+    touch /opt/teamspeak/.ts3server_license_accepted && \
+    tar jxf /tmp/teamspeak.tar.bz2 -C /opt/teamspeak --strip-components=1 && \
+    rm -f /tmp/teamspeak.tar.bz2 && \
+    yum clean all
 
 COPY container-files /
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TeamSpeak 3 Server in a Docker (Alpine)
+# TeamSpeak 3 Server in a Docker (CentOS7)
 
 [![Build Status](https://jenkins.ozgo.info/jenkins/buildStatus/icon?job=gh-pozgo-docker-teamspeak)](https://jenkins.ozgo.info/jenkins/job/gh-pozgo-docker-teamspeak/)
 [![GitHub Open Issues](https://img.shields.io/github/issues/pozgo/docker-teamspeak.svg)](https://github.com/pozgo/docker-teamspeak/issues)  
@@ -12,7 +12,7 @@ Felling like supporting me in my projects use donate button. Thank You!
 
 [![Deploy to Docker Cloud](https://files.cloud.docker.com/images/deploy-to-dockercloud.svg)](https://cloud.docker.com/stack/deploy/?repo=https://github.com/pozgo/docker-teamspeak/tree/master)
 
-[Docker Image](https://hub.docker.com/r/polinux/teamspeak/) with TeamSpeak 3 Server using Alpine Linux to make image super small. Size is < `25Mb`
+[Docker Image](https://hub.docker.com/r/polinux/teamspeak/) with TeamSpeak 3 Server using CentOS7
 
 ### Build Image
 

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -1,6 +1,5 @@
-#!/bin/ash
+#!/usr/bin/bash
 set -e
-TS3_DATABASE="/opt/teamspeak/ts3server.sqlitedb"
 # Functions
 sig_int () {
     echo "SIGINT received"
@@ -12,22 +11,7 @@ sig_term () {
     kill -15 ${pid}
 }
 
-install_ts3() {
-  echo "Installing Teamspeak version: ${TS3_VERSION}"
-  mkdir -p /opt/teamspeak
-  touch /opt/teamspeak/.ts3server_license_accepted
-  tar jxf /tmp/teamspeak.tar.bz2 -C /opt/teamspeak --strip-components=1
-  rm -f /tmp/teamspeak.tar.bz2
-  echo "Teamspeak version: ${TS3_VERSION} installed."
-}
-
-### Action
-
-if [[ ! -e ${TS3_DATABASE} ]]; then
-  install_ts3
-fi
-
-./opt/teamspeak/ts3server_minimal_runscript.sh $@ &
+/opt/teamspeak/ts3server_minimal_runscript.sh $@ &
 pid=$!
 trap sig_int  INT
 trap sig_term TERM


### PR DESCRIPTION
Changes:

- migrated from `Alpine` to `CentOS7` base image
Requred to use full blown linux distro due to missing libraries in latest versions of `teamspeak` 
