### PR TITLE
Updated to 3.13.7 and Debian 12 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
-FROM centos:7
+FROM debian:12
 
-ENV  TS3_VERSION=3.13.2
+ENV  \
+    TS3_VERSION=3.13.7 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
 
 RUN \
-    yum install -y wget bzip2 glibc && \
+    apt update && \
+    apt install -y wget bzip2 libc6 && \
     wget http://files.teamspeak-services.com/releases/server/${TS3_VERSION}/teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2 -O /tmp/teamspeak.tar.bz2 && \
     mkdir -p /opt/teamspeak && \
     touch /opt/teamspeak/.ts3server_license_accepted && \
     tar jxf /tmp/teamspeak.tar.bz2 -C /opt/teamspeak --strip-components=1 && \
-    rm -f /tmp/teamspeak.tar.bz2 && \
-    yum clean all
+    rm -f /tmp/teamspeak.tar.bz2
 
 COPY container-files /
 
-ENTRYPOINT ["/bootstrap.sh"]
+#ENTRYPOINT ["/bootstrap.sh"]
 
-EXPOSE 9987/udp 10011 30033
+EXPOSE 9987/udp 10011 10080 30033

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN \
 
 COPY container-files /
 
-#ENTRYPOINT ["/bootstrap.sh"]
+ENTRYPOINT ["/bootstrap.sh"]
 
 EXPOSE 9987/udp 10011 10080 30033

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# TeamSpeak 3 Server in a Docker (CentOS7)
+# TeamSpeak 3 Server in a Docker (`Debian 12`)
 
-[![Build & Test TeamSpeak Server 3](https://github.com/pozgo/docker-teamspeak/workflows/Build%20&%20Test%20TeamSpeak%20Server%203/badge.svg)](https://github.com/pozgo/docker-teamspeak/actions)    
 [![GitHub Open Issues](https://img.shields.io/github/issues/pozgo/docker-teamspeak.svg)](https://github.com/pozgo/docker-teamspeak/issues)  
 [![Stars](https://img.shields.io/github/stars/pozgo/docker-teamspeak.svg?style=social&label=Stars)]()
 [![Fork](https://img.shields.io/github/forks/pozgo/docker-teamspeak.svg?style=social&label=Fork)]()  
@@ -10,7 +9,7 @@
 Felling like supporting me in my projects use donate button. Thank You!  
 [![](https://img.shields.io/badge/donate-PayPal-blue.svg)](https://www.paypal.me/POzgo)
 
-[Docker Image](https://hub.docker.com/r/polinux/teamspeak/) with TeamSpeak 3 Server using CentOS7
+[Docker Image](https://hub.docker.com/r/polinux/teamspeak/) with TeamSpeak 3 Server using Debian 12  
 This image was moved to CentOS7 as base due to libraries mismatch on Alpine linux. It might be a bit bigger than usual but it's still small (~84Mb).
 
 ### Build Image


### PR DESCRIPTION
Changes: 

- Updated TeamSpeak to `3.13.7`  
- Moved Base Image to Debian 12 (CentOS 7 deprecated long time ago)
- Added Web Query port (`10080`) 